### PR TITLE
Autodetect external network

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Openstack IDR Network
 =====================
 
-Create an Openstack network including external router for use with the IDR playbooks.
+Create an Openstack network including optional external router for use with the IDR playbooks.
 
 
 Role Variables
@@ -18,8 +18,6 @@ Optional variables:
 - `idr_network_subnet_name`: Subnet name
 - `idr_network_router_name`: Router name
 - `idr_network_dns`: List of DNS servers (default: Google DNS server)
-
-- `idr_environment`: Use this as a group prefix. This is required to ensure servers can lookup the address of other servers in the group, and is particularly important if multiple groups of servers are running in the same project. The default is `idr` but you should almost always set it to something else.
 
 
 Author Information

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Defaults: `defaults/main.yml`
 
 Required variables:
 - `idr_network_name`: Base name for the IDR network components
-- `idr_network_external_name`: Name of the external network (this should be created by an OpenStack admin)
 
 Optional variables:
+- `idr_network_route_external`: If `True` automatically lookup and connect to an external network, if `False` create an internal router only, default `True`
 - `idr_network_subnet`: Subnet CIDR
 - `idr_network_subnet_name`: Subnet name
 - `idr_network_router_name`: Router name

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ idr_network_router_name: "{{ idr_network_name }}-router"
 idr_network_dns:
 - 8.8.8.8
 - 8.8.4.4
+
+idr_network_route_external: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,11 +6,13 @@
   when: "{{ idr_network_route_external }}"
   # Automatically creates variable openstack_networks
 
-- os_network:
+- name: idr | create network
+  os_network:
     name: "{{ idr_network_name }}"
     state: present
 
-- os_subnet:
+- name: idr | create subnet
+  os_subnet:
     cidr: "{{ idr_network_subnet }}"
     dns_nameservers: "{{ idr_network_dns }}"
     name: "{{ idr_network_subnet_name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
 # Playbook for creating OpenStack IDR Networks
 
+- name: idr | network facts
+  os_networks_facts:
+  when: "{{ idr_network_route_external }}"
+  # Automatically creates variable openstack_networks
+
 - os_network:
     name: "{{ idr_network_name }}"
     state: present
@@ -12,9 +17,36 @@
     network_name: "{{ idr_network_name }}"
     state: present
 
-- os_router:
+- name: idr | debug external network
+  debug:
+    msg: >-
+      "External network: "
+      {{
+         ['name', 'id'] | map('extract', openstack_networks |
+         selectattr('router:external', 'equalto', True) |
+         first) | list
+      }}
+    verbosity: 1
+  when: "{{ idr_network_route_external }}"
+
+- name: idr | create external router
+  os_router:
     interfaces:
     - "{{ idr_network_subnet_name }}"
     name: "{{ idr_network_router_name }}"
-    network: "{{ idr_network_external_name }}"
+    network: >-
+      {{
+        (openstack_networks |
+         selectattr("router:external", "equalto", True) |
+         first).id
+      }}
     state: present
+  when: "{{ idr_network_route_external }}"
+
+- name: idr | create internal router
+  os_router:
+    interfaces:
+    - "{{ idr_network_subnet_name }}"
+    name: "{{ idr_network_router_name }}"
+    state: present
+  when: "{{ not idr_network_route_external }}"


### PR DESCRIPTION
This removes the requirement to provide the name of the external network.

This is a breaking change, tag 2.0.0:
- Removed `idr_network_external_name`, it is no longer possible to explicitly choose the external network
- Added `idr_network_route_external` to optionally disable external routing, default is to automatically detect and connect to the external network