### PR TITLE
Always run os_networks_facts

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,7 @@
 - name: idr | network facts
   os_networks_facts:
   when: "{{ idr_network_route_external }}"
+  always_run: yes
   # Automatically creates variable openstack_networks
 
 - name: idr | create network


### PR DESCRIPTION
This allows the role to be successfully run in check-mode when there are no changes.

Without this the `openstack_networks` variable isn't populated, so all comparisons fail.