### PR TITLE
Change external networks parameter to allow explicit network to be specified (IDR-0.4.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 
 install:
   # Install ansible
-  - pip install ansible
+  - pip install ome-ansible-molecule-dependencies
 
   # Check ansible version
   - ansible --version
@@ -24,6 +24,7 @@ install:
 script:
   # Basic role syntax check
   - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - ansible-lint tests/test.yml
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Optional variables:
 - `idr_network_subnet`: Subnet CIDR
 - `idr_network_subnet_name`: Subnet name
 - `idr_network_router_name`: Router name
-- `idr_network_dns`: List of DNS servers (default: Google DNS server)
+- `idr_network_dns`: List of DNS servers (default: Google's DNS servers)
 
 
 Author Information

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Required variables:
 - `idr_network_name`: Base name for the IDR network components
 
 Optional variables:
-- `idr_network_route_external`: If `True` automatically lookup and connect to an external network, if `False` create an internal router only, default `True`
+- `idr_network_route_external`: Create an externally-routable network.
+   If `True` automatically lookup the external network.
+   If this is a string then route to the external network with this name or id (if you have multiple external networks you should use this to avoid problems).
+   If `False` create an internal router only, default `True`.
 - `idr_network_subnet`: Subnet CIDR
 - `idr_network_subnet_name`: Subnet name
 - `idr_network_router_name`: Router name

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Required variables:
 
 Optional variables:
 - `idr_network_route_external`: Create an externally-routable network.
-   If `True` automatically lookup the external network.
-   If this is a string then route to the external network with this name or id (if you have multiple external networks you should use this to avoid problems).
-   If `False` create an internal router only, default `True`.
+   If `auto` (default) automatically lookup the external network.
+   If this is a string then route to the external network with this name or id (if you have multiple external networks you must use this to avoid problems).
+   If `''` create an internal router only.
 - `idr_network_subnet`: Subnet CIDR
 - `idr_network_subnet_name`: Subnet name
 - `idr_network_router_name`: Router name

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,4 +11,6 @@ idr_network_dns:
 - 8.8.8.8
 - 8.8.4.4
 
-idr_network_route_external: True
+# auto: autodetect external network
+# non-empty string: name or ID of external network
+idr_network_route_external: "auto"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   description: Create an Openstack network including external router
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.1
+  min_ansible_version: 2.3
   platforms:
   - name: EL
     versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,8 +3,8 @@
 
 - name: idr | network facts
   os_networks_facts:
-  when: "{{ idr_network_route_external }}"
-  always_run: yes
+  when: idr_network_route_external == 'auto'
+  check_mode: no
   # Automatically creates variable openstack_networks
 
 - name: idr | create network
@@ -30,9 +30,9 @@
          first) | list
       }}
     verbosity: 1
-  when: "{{ idr_network_route_external }}"
+  when: idr_network_route_external == 'auto'
 
-- name: idr | create external router
+- name: idr | create external router (auto-detected external)
   os_router:
     interfaces:
     - "{{ idr_network_subnet_name }}"
@@ -44,7 +44,18 @@
          first).id
       }}
     state: present
-  when: "{{ idr_network_route_external }}"
+  when: idr_network_route_external == 'auto'
+
+- name: idr | create external router (specified external)
+  os_router:
+    interfaces:
+    - "{{ idr_network_subnet_name }}"
+    name: "{{ idr_network_router_name }}"
+    network: "{{ idr_network_route_external }}"
+    state: present
+  when: >
+    (idr_network_route_external | length > 0) and
+    (idr_network_route_external != 'auto')
 
 - name: idr | create internal router
   os_router:
@@ -52,4 +63,4 @@
     - "{{ idr_network_subnet_name }}"
     name: "{{ idr_network_router_name }}"
     state: present
-  when: "{{ not idr_network_route_external }}"
+  when: not idr_network_route_external


### PR DESCRIPTION
If there are multiple external networks the autodetection may choose an unsuitable network. This breaking change makes `idr_network_route_external` a string instead of a bool. The default `auto` is equivalent to the previous behaviour `True`

I could make this non-breaking by adding another parameter, but given this is specific to the IDR I don't think it's worth the added logic.

Also some fixes to deprecated syntax, and bumped Ansible to the current tested version